### PR TITLE
support for multiple importers in node-sass

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = function(url, prev, done) {
 		return null;
 	}
 
-    let cwd = path.dirname(prev);
+	let cwd = path.dirname(prev);
 
 	glob(url, {cwd: cwd}, (err, files) => {
 		if (err) {

--- a/index.js
+++ b/index.js
@@ -5,10 +5,10 @@ const path = require("path");
 
 module.exports = function(url, prev, done) {
 	if (!glob.hasMagic(url)) {
-		return done({file: url});
+		return null;
 	}
 
-	let cwd = path.join(this.options.includePaths, path.dirname(prev));
+    let cwd = path.dirname(prev);
 
 	glob(url, {cwd: cwd}, (err, files) => {
 		if (err) {


### PR DESCRIPTION
Hi there!

According to node-sass specs: "If an importer does not want to handle a particular path, it should return null". So if it's not a string with globbing we just return null and move on to the next importer.

So in order to make it work (for my case, with compass importer and npm module importer) I have to make this few modifications. Also the 'cwd' was wrong for me, but I am not sure the update on it will cover all cases.

